### PR TITLE
Add support for iOSDeviceManager specific logging to macOS Framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
+Products
 
 # CocoaPods
 #

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,10 @@ Pods/
 Podfile.lock
 LumberjackUser*.h
 .DS_Store
+
+# vim and emacs
+*.swp
+*.swo
+*~
+\#*\#
+.\#*

--- a/Classes/iOSDeviceManagerLogging.h
+++ b/Classes/iOSDeviceManagerLogging.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface iOSDeviceManagerLogging : NSObject
+
++ (void)startLumberjackLogging;
+
+@end
+

--- a/Classes/iOSDeviceManagerLogging.m
+++ b/Classes/iOSDeviceManagerLogging.m
@@ -1,0 +1,230 @@
+
+#ifndef DD_LEGACY_MACROS
+#define DD_LEGACY_MACROS 0
+#endif
+
+#import "iOSDeviceManagerLogging.h"
+#import "DDTTYLogger.h"
+#import "DDASLLogger.h"
+#import "DDFileLogger.h"
+#import "DDLog.h"
+#import <libkern/OSAtomic.h>
+
+#pragma mark - IDMLogFileManager
+
+static NSString *const IDMLogFileNameDateFormat = @"yyyy-MM-dd-HH-mm-ss";
+static NSString *const IDMLogFileNameDateFormatterKey = @"sh.calaba-IDMLogFileNameFormatter-NSDateFormatter";
+static NSString *const IDMLogFilePrefix = @"idm-";
+
+@interface DDLogFileManagerDefault (iOSDeviceManagerAdditions)
+
+- (void)deleteOldLogFiles;
+
+@end
+
+@interface IDMLogFileManager : DDLogFileManagerDefault
+
+@end
+
+@implementation IDMLogFileManager
+
+
+- (NSString *)newLogFileName {
+
+  NSDateFormatter *dateFormatter = [self logFileDateFormatter];
+  NSString *formattedDate = [dateFormatter stringFromDate:[NSDate date]];
+
+  return [NSString stringWithFormat:@"%@%@.log", IDMLogFilePrefix, formattedDate];
+}
+
+
+- (NSDateFormatter *)logFileDateFormatter {
+  NSMutableDictionary *dictionary = [[NSThread currentThread] threadDictionary];
+  NSString *dateFormat = IDMLogFileNameDateFormat;
+  NSDateFormatter *dateFormatter = dictionary[IDMLogFileNameDateFormatterKey];
+
+  if (dateFormatter == nil) {
+    dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+    [dateFormatter setDateFormat:dateFormat];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0]];
+    dictionary[IDMLogFileNameDateFormatterKey] = dateFormatter;
+  }
+
+  return dateFormatter;
+}
+
+- (NSString *)createNewLogFile {
+  NSString *fileName = [self newLogFileName];
+  NSString *logsDirectory = [self logsDirectory];
+
+  NSString *path = [logsDirectory stringByAppendingPathComponent:fileName];
+  while ([[NSFileManager defaultManager] fileExistsAtPath:path]) {
+    path = [logsDirectory stringByAppendingPathComponent:[self newLogFileName]];
+  }
+
+  NSDictionary *attributes = nil;
+
+  [[NSFileManager defaultManager] createFileAtPath:path
+                                          contents:nil
+                                        attributes:attributes];
+
+
+  [self deleteOldLogFiles];
+
+  NSString *currentSymlink = [logsDirectory stringByAppendingPathComponent:@"current.log"];
+  [[NSFileManager defaultManager] removeItemAtPath:currentSymlink error:nil];
+
+  [[NSFileManager defaultManager] createSymbolicLinkAtPath:currentSymlink
+                                       withDestinationPath:path error:nil];
+
+  return path;
+}
+
+- (BOOL)isLogFile:(NSString *)fileName {
+
+  BOOL hasProperPrefix = [fileName hasPrefix:IDMLogFilePrefix];
+  BOOL hasProperSuffix = [fileName hasSuffix:@".log"];
+  BOOL hasProperDate = NO;
+
+  if (hasProperPrefix && hasProperSuffix) {
+    NSUInteger lengthOfMiddle = fileName.length - IDMLogFilePrefix.length - @".log".length;
+
+    // Date string should have at least 19 characters: "2013-12-03-17-14-10"
+    if (lengthOfMiddle >= 19) {
+      NSRange range = NSMakeRange(IDMLogFilePrefix.length, lengthOfMiddle);
+
+      NSString *middle = [fileName substringWithRange:range];
+      NSArray *components = [middle componentsSeparatedByString:@"-"];
+
+      if (components.count == 6) {
+        NSDateFormatter *dateFormatter = [self logFileDateFormatter];
+        NSDate *date = [dateFormatter dateFromString:middle];
+
+        if (date) {
+          hasProperDate = YES;
+        }
+      }
+    }
+  }
+
+  return (hasProperPrefix && hasProperDate && hasProperSuffix);
+}
+
+
+@end
+
+static NSString *const IDMLogFormatterDateFormat = @"yyyy-MM-dd HH:mm:ss.SSS";
+static NSString *const IDMLogFormatterDateFormatterKey = @"sh.calaba-IDMLogFormatter-NSDateFormatter";
+
+@interface IDMLogFormatter : NSObject <DDLogFormatter>  {
+  int32_t atomicLoggerCount;
+  NSDateFormatter *threadUnsafeDateFormatter;
+}
+
+- (NSString *)stringFromDate:(NSDate *)date;
+
+@end
+
+
+@implementation IDMLogFormatter
+
+- (NSString *)stringFromDate:(NSDate *)date {
+  int32_t loggerCount = OSAtomicAdd32(0, &atomicLoggerCount);
+
+  if (loggerCount <= 1) {
+    // Single-threaded mode.
+
+    if (!threadUnsafeDateFormatter) {
+      threadUnsafeDateFormatter = [[NSDateFormatter alloc] init];
+      [threadUnsafeDateFormatter setDateFormat:IDMLogFormatterDateFormat];
+    }
+
+    return [threadUnsafeDateFormatter stringFromDate:date];
+  } else {
+    // Multi-threaded mode.
+    // NSDateFormatter is NOT thread-safe.
+    NSMutableDictionary *threadDictionary = [[NSThread currentThread] threadDictionary];
+    NSDateFormatter *dateFormatter = threadDictionary[IDMLogFormatterDateFormatterKey];
+
+    if (dateFormatter == nil) {
+      dateFormatter = [[NSDateFormatter alloc] init];
+      [dateFormatter setDateFormat:IDMLogFormatterDateFormat];
+
+      threadDictionary[IDMLogFormatterDateFormatterKey] = dateFormatter;
+    }
+
+    return [dateFormatter stringFromDate:date];
+  }
+}
+
+- (NSString *)formatLogMessage:(DDLogMessage *)logMessage {
+  NSString *logLevel;
+  switch (logMessage.flag) {
+    case DDLogFlagError    : logLevel = @"ERROR"; break;
+    case DDLogFlagWarning  : logLevel = @" WARN"; break;
+    case DDLogFlagInfo     : logLevel = @ "INFO"; break;
+    case DDLogFlagDebug    : logLevel = @"DEBUG"; break;
+    default                : logLevel = @"DEBUG"; break;
+  }
+
+  NSString *dateAndTime = [self stringFromDate:(logMessage.timestamp)];
+  NSString *logMsg = logMessage->_message;
+
+  NSString *filenameAndNumber = [NSString stringWithFormat:@"%@:%@",
+                                 logMessage.fileName, @(logMessage.line)];
+  return [NSString stringWithFormat:@"%@ %@ %@ | %@",
+          dateAndTime,
+          logLevel,
+          filenameAndNumber,
+          logMsg];
+}
+
+- (void)didAddToLogger:(id <DDLogger>)logger {
+  OSAtomicIncrement32(&atomicLoggerCount);
+}
+
+- (void)willRemoveFromLogger:(id <DDLogger>)logger {
+  OSAtomicDecrement32(&atomicLoggerCount);
+}
+
+@end
+
+#pragma mark - iOSDeviceManagerLogging
+
+@implementation iOSDeviceManagerLogging
+
++ (void)startLumberjackLogging {
+
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+  // Xcode Console Logging - maybe enable this logger at runtime if we are
+  // running from within the Xcode IDE or with xcodebuild test.
+  // [[DDTTYLogger sharedInstance] setLogFormatter:[IDMLogFormatter new]];
+  // [DDLog addLogger:[DDTTYLogger sharedInstance]];
+
+  // Apple System Logger
+  // [[DDASLLogger sharedInstance] setLogFormatter:[IDMLogFormatter new]];
+  // [DDLog addLogger:[DDASLLogger sharedInstance]];
+
+    NSString *logDirectory = [[[NSHomeDirectory()
+                                stringByAppendingPathComponent:@".calabash"]
+                               stringByAppendingPathComponent:@"iOSDeviceManager"]
+                              stringByAppendingPathComponent:@"logs"];
+    IDMLogFileManager *logFileManager = [[IDMLogFileManager alloc]
+                                         initWithLogsDirectory:logDirectory];
+
+    DDFileLogger *fileLogger = [[DDFileLogger alloc]
+                                initWithLogFileManager:logFileManager];
+
+
+    //Logfile rolls every day or 1 mb of log
+    fileLogger.rollingFrequency = 60 * 60 * 24;
+    fileLogger.maximumFileSize = 1024 * 1024; //1Mb
+    fileLogger.logFileManager.maximumNumberOfLogFiles = 10;
+    fileLogger.logFormatter = [IDMLogFormatter new];
+    [DDLog addLogger:fileLogger];
+  });
+}
+
+@end

--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -40,3 +40,6 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 
 // CLI
 #import <CocoaLumberjack/CLIColor.h>
+
+// Interfaces for specific tools
+#import <CocoaLumberjack/iOSDeviceManagerLogging.h>

--- a/Framework/Lumberjack/CocoaLumberjack.h
+++ b/Framework/Lumberjack/CocoaLumberjack.h
@@ -39,6 +39,4 @@ FOUNDATION_EXPORT const unsigned char CocoaLumberjackVersionString[];
 #import <CocoaLumberjack/DDFileLogger.h>
 
 // CLI
-#if defined(DD_CLI) || !__has_include(<AppKit/NSColor.h>)
 #import <CocoaLumberjack/CLIColor.h>
-#endif

--- a/Lumberjack.xcodeproj/project.pbxproj
+++ b/Lumberjack.xcodeproj/project.pbxproj
@@ -182,6 +182,8 @@
 		E5D89BA81994749300C180CF /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA51994749300C180CF /* DDAssertMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BA91994749300C180CF /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = E5D89BA61994749300C180CF /* DDLogMacros.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E5D89BAD199494B600C180CF /* CocoaLumberjack.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCB3185114EB418E001CFBEE /* CocoaLumberjack.framework */; };
+		F57A63D61DD23F1E00BA2B2A /* iOSDeviceManagerLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = F57A63D21DD23F1E00BA2B2A /* iOSDeviceManagerLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F57A63D71DD23F1E00BA2B2A /* iOSDeviceManagerLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = F57A63D31DD23F1E00BA2B2A /* iOSDeviceManagerLogging.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -458,6 +460,8 @@
 		E5D89BA41994749300C180CF /* CocoaLumberjack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CocoaLumberjack.h; sourceTree = "<group>"; };
 		E5D89BA51994749300C180CF /* DDAssertMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDAssertMacros.h; sourceTree = "<group>"; };
 		E5D89BA61994749300C180CF /* DDLogMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DDLogMacros.h; sourceTree = "<group>"; };
+		F57A63D21DD23F1E00BA2B2A /* iOSDeviceManagerLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iOSDeviceManagerLogging.h; sourceTree = "<group>"; };
+		F57A63D31DD23F1E00BA2B2A /* iOSDeviceManagerLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = iOSDeviceManagerLogging.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -777,6 +781,8 @@
 				DA9C20C9192A0E0000AB7171 /* DDTTYLogger.m */,
 				93483CFA1D09E39000AD40D6 /* CLIColor.h */,
 				93483CFB1D09E39000AD40D6 /* CLIColor.m */,
+				F57A63D21DD23F1E00BA2B2A /* iOSDeviceManagerLogging.h */,
+				F57A63D31DD23F1E00BA2B2A /* iOSDeviceManagerLogging.m */,
 				DA9C20CA192A0E0000AB7171 /* Extensions */,
 			);
 			name = Lumberjack;
@@ -938,6 +944,7 @@
 				18F3BF161A81D9A400692297 /* CocoaLumberjack.h in Headers */,
 				93483CFC1D09E39000AD40D6 /* CLIColor.h in Headers */,
 				DA9C20D7192A0E0000AB7171 /* DDFileLogger.h in Headers */,
+				F57A63D61DD23F1E00BA2B2A /* iOSDeviceManagerLogging.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1615,6 +1622,7 @@
 				DA9C20D2192A0E0000AB7171 /* DDAbstractDatabaseLogger.m in Sources */,
 				93483CFD1D09E39000AD40D6 /* CLIColor.m in Sources */,
 				DA9C20D6192A0E0000AB7171 /* DDASLLogger.m in Sources */,
+				F57A63D71DD23F1E00BA2B2A /* iOSDeviceManagerLogging.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2508,6 +2516,7 @@
 				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Debug;
@@ -2537,6 +2546,7 @@
 				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALID_ARCHS = "arm64 armv7 armv7s i386 x86_64";
+				VERSIONING_SYSTEM = "apple-generic";
 				WRAPPER_EXTENSION = framework;
 			};
 			name = Release;

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+
+macos-framework:
+	bin/make/macos-framework.sh
+
+macos-install-to-fb-sim-control:
+	bin/make/install-to-fb-sim-control.sh
+

--- a/bin/copy-with-ditto.sh
+++ b/bin/copy-with-ditto.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+source bin/log-functions.sh
+
+function ditto_or_exit {
+  ditto "${1}" "${2}"
+  if [ "$?" != 0 ]; then
+    error "Could not copy:"
+    error "  source: ${1}"
+    error "  target: ${2}"
+    if [ ! -e "${1}" ]; then
+      error "The source file does not exist"
+      error "Did a previous xcodebuild step fail?"
+    fi
+    error "Exiting 1"
+    exit 1
+  fi
+}
+

--- a/bin/log-functions.sh
+++ b/bin/log-functions.sh
@@ -1,0 +1,36 @@
+# Log functions for scripts.
+#
+# Suitable for Xcode Run Script Build Phase and command line scripts.
+#
+# Usage:
+#
+# source bin/log-functions.sh
+
+function info {
+  if [ "${TERM}" = "dumb" ]; then
+    echo "INFO: $1"
+  else
+    echo "$(tput setaf 2)INFO: $1$(tput sgr0)"
+  fi
+}
+
+function error {
+  if [ "${TERM}" = "dumb" ]; then
+    echo "ERROR: $1"
+  else
+    echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
+  fi
+}
+
+function banner {
+  if [ "${TERM}" = "dumb" ]; then
+    echo ""
+    echo "######## $1 ########"
+    echo ""
+  else
+    echo ""
+    echo "$(tput setaf 5)######## $1 ########$(tput sgr0)"
+    echo ""
+  fi
+}
+

--- a/bin/make/install-to-fb-sim-control.sh
+++ b/bin/make/install-to-fb-sim-control.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+source bin/log-functions.sh
+source bin/copy-with-ditto.sh
+
+if [ -z "${FBSIMCONTROL_PATH}" ]; then
+  if [ -e "../FBSimulatorControl" ]; then
+    FBSIMCONTROL_PATH="../FBSimulatorControl"
+  fi
+fi
+
+if [ ! -d "${FBSIMCONTROL_PATH}" ]; then
+  error "FBSimulatorControl does not exist at path:"
+  error "  ${FBSIMCONTROL_PATH}"
+  error "Set the FBSIMCONTROL_PATH=path/to/FBSimulatorControl or"
+  error "checkout the calabash fork of the FBSimulatorControl repo to ../"
+  exit 1
+fi
+
+make macos-framework
+
+banner "Installing to FBSimulatorControl/Vendor"
+
+SOURCE="Products/macOS/CocoaLumberjack.framework"
+TARGET="${FBSIMCONTROL_PATH}/Vendor/CocoaLumberjack.framework"
+
+ditto_or_exit "${SOURCE}" "${TARGET}"
+
+info "Installed ${TARGET}"
+

--- a/bin/make/macos-framework.sh
+++ b/bin/make/macos-framework.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+source bin/log-functions.sh
+source bin/copy-with-ditto.sh
+
+if [ "${XCPRETTY}" = "0" ]; then
+  USE_XCPRETTY=
+else
+  USE_XCPRETTY=`which xcpretty | tr -d '\n'`
+fi
+
+if [ ! -z ${USE_XCPRETTY} ]; then
+  XC_PIPE='xcpretty -c'
+else
+  XC_PIPE='cat'
+fi
+
+XC_PROJECT="Lumberjack.xcodeproj"
+XC_TARGET="CocoaLumberjack"
+XC_CONFIG=Release
+BUILD_DIR=build/macOS
+INSTALL_DIR=Products/macOS
+FRAMEWORK_NAME=CocoaLumberjack.framework
+
+SOURCE="${BUILD_DIR}/${XC_CONFIG}/${FRAMEWORK_NAME}"
+TARGET="${INSTALL_DIR}/${FRAMEWORK_NAME}"
+
+rm -rf "${BUILD_DIR}"
+mkdir "${BUILD_DIR}"
+rm -rf "${INSTALL_DIR}"
+mkdir "${INSTALL_DIR}"
+
+banner "Making macOS Framework"
+
+xcrun xcodebuild \
+  SYMROOT="${BUILD_DIR}" \
+  OBJROOT="${BUILD_DIR}" \
+  -project ${XC_PROJECT} \
+  -target ${XC_TARGET} \
+  -configuration ${XC_CONFIG} \
+  -sdk macosx \
+  GCC_TREAT_WARNINGS_AS_ERRORS=NO \
+  GCC_GENERATE_TEST_COVERAGE_FILES=NO \
+  GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO \
+  build | $XC_PIPE
+
+info "Built ${SOURCE}"
+
+ditto_or_exit "${SOURCE}" "${TARGET}"
+
+info "Installed ${TARGET}"


### PR DESCRIPTION
### Motivation

Adds custom log file manager and formatter to the macOS CocoaLumberjack.framework so it can be distributed with FBSimulatorControl.

### Make

```
# Responds to FBSIMULATORCONTROL_PATH
$ make macos-install-to-fb-sim-control
```

### Start Logging

```
# iOSDeviceManager main.m

#import <CocoaLumberjack/CocoaLumberjack.h>

int main(int argc, const char * argv[]) {
    @autoreleasepool {
        [iOSDeviceManagerLogging startLumberjackLogging];
        return [CLI process:[NSProcessInfo processInfo].arguments];
    }
}
```

The CocoaLumberjack.framework is added to the FBSimulatorControl targets as an embedded framework and is distributed in the `../Frameworks` directory so it can be used by iOSDeviceManager.
